### PR TITLE
Turn timer firing off by default

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,7 +32,7 @@ ENABLE_TIMER=true
 # Maximum interval range in minutes for the random timer
 TIMER_INTERVAL_MINUTES=15
 # Probability of the timer firing (0.0 to 1.0)
-FIRING_PROBABILITY=0.1
+FIRING_PROBABILITY=0.0
 
 # App Configuration
 PORT=3001


### PR DESCRIPTION
Timer firing defaults to 0.1 by default, which can burn through a _ton_ of tokens if you deploy on a persistent service like Railway. We should be careful about a default that uses idle tokens. This PR turns the firing default off.